### PR TITLE
Changing the items collection breaks multisort.

### DIFF
--- a/src/classes/grid.js
+++ b/src/classes/grid.js
@@ -629,7 +629,9 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
             };
             if (isArr) {
                 self.clearSortingData();
+                var sortData = evt && evt.sortData || {};
                 angular.forEach(col, function (c, i) {
+                    c.sortDirection = sortData[c.field] && sortData[c.field].sortDirection || 'asc';
                     c.sortPriority = i + 1;
                     push(c);
                 });
@@ -649,18 +651,27 @@ var ngGrid = function ($scope, options, sortService, domUtilityService, $filter,
         } else {
             self.config.sortInfo.columns = [];
         }
+
+        var sortData = {};
+        var cols = [];
         angular.forEach($scope.columns, function(c) {
             var i = self.config.sortInfo.fields.indexOf(c.field);
             if (i !== -1) {
                 c.sortDirection = self.config.sortInfo.directions[i] || 'asc';
                 self.config.sortInfo.columns[i] = c;
+                cols[i] = c;
+
+                sortData[c.field] = {
+                    sortDirection: c.sortDirection, sortPriority: c.sortPriority
+                };
             }
         });
 
-        var cols = angular.copy(self.config.sortInfo.columns);
-        angular.forEach(cols, function(c){
-            self.sortData(c);
-        });
+        if (cols.length === 1) {
+            self.sortData(cols[0]);
+        } else {
+            self.sortData(cols, { sortData: sortData });
+        }
     };
     self.sortActual = function() {
         if (!self.config.useExternalSorting) {


### PR DESCRIPTION
The sortInfo.columns would have its length reset to 0 while adding back
in the first sort column, meaning that the 'forEach' would only process
the first column before exiting.
