### PR TITLE
Updated column-resizer to account for bold text

### DIFF
--- a/src/features/resize-columns/js/ui-grid-column-resizer.js
+++ b/src/features/resize-columns/js/ui-grid-column-resizer.js
@@ -515,30 +515,29 @@
           // Get the cell contents so we measure correctly. For the header cell we have to account for the sort icon and the menu buttons, if present
           var cells = renderContainerElm.querySelectorAll('.' + uiGridConstants.COL_CLASS_PREFIX + col.uid + ' .ui-grid-cell-contents');
           Array.prototype.forEach.call(cells, function (cell) {
-              // Get the cell width
-              // gridUtil.logDebug('width', gridUtil.elementWidth(cell));
 
               // Account for the menu button if it exists
               var menuButton;
               if (angular.element(cell).parent().hasClass('ui-grid-header-cell')) {
                 menuButton = angular.element(cell).parent()[0].querySelectorAll('.ui-grid-column-menu-button');
               }
+              // Make the element float since it's a div and can expand to fill its container
+              // include the cell's font properties since they affect the width
+              var cellElement = angular.element(cell);
 
-              //text becomes bold when font weight = 600
-              //this needs to be checked here because the fakeElement doesn't contain the font weight
-              var textIsBold = parseInt(angular.element(cell).css('font-weight')) > 500; 
+              var cellStyle = window.getComputedStyle(cellElement[0]);
 
-              gridUtil.fakeElement(cell, {}, function(newElm) {
-                // Make the element float since it's a div and can expand to fill its container
-                var e = angular.element(newElm);
-                e.attr('style', 'float: left');
-                var width = gridUtil.elementWidth(e);
-                
-                if (textIsBold) {
-                  //1.05 is the smallest reasonable multiplier that prevents bold text from being truncated
-                  var boldTextOffsetMultiplier = 1.05;
-                  width = width * boldTextOffsetMultiplier;
+              var style = {'float':'left'};
+              for ( var i in cellStyle ) {
+                if(i.startsWith('font')){
+                  style[i] = cellStyle[i];
                 }
+              }
+
+              gridUtil.fakeElement(cell, style, function(newElm) {
+                
+                var e = angular.element(newElm);
+                var width = gridUtil.elementWidth(newElm);
 
                 if (menuButton) {
                   var menuButtonWidth = gridUtil.elementWidth(menuButton);

--- a/src/features/resize-columns/js/ui-grid-column-resizer.js
+++ b/src/features/resize-columns/js/ui-grid-column-resizer.js
@@ -522,22 +522,32 @@
                 menuButton = angular.element(cell).parent()[0].querySelectorAll('.ui-grid-column-menu-button');
               }
               // Make the element float since it's a div and can expand to fill its container
-              // include the cell's font properties since they affect the width
-              var cellElement = angular.element(cell);
+              // include the cell's font properties since they affect the width.
+              var cellElement = angular.element(cell);            
 
-              var cellStyle = window.getComputedStyle(cellElement[0]);
-
-              var style = {'float':'left'};
-              for ( var i in cellStyle ) {
-                if(i.startsWith('font')){
-                  style[i] = cellStyle[i];
-                }
-              }
+              var style = {
+                  'float':'left',
+                  'font': cellElement.css('font'),
+                  'fontDisplay': cellElement.css('fontDisplay'),
+                  'fontFamily': cellElement.css('fontFamily'),
+                  'fontFeatureSettings': cellElement.css('fontFeatureSettings'),
+                  'fontKerning': cellElement.css('fontKerning'),
+                  'fontSize': cellElement.css('fontSize'),
+                  'fontStretch': cellElement.css('fontStretch'),
+                  'fontStyle': cellElement.css('fontStyle'),
+                  'fontVariant': cellElement.css('fontVariant'),
+                  'fontVariantCaps': cellElement.css('fontVariantCaps'),
+                  'fontVariantEastAsian': cellElement.css('fontVariantEastAsian'),
+                  'fontVariantLigatures': cellElement.css('fontVariantLigatures'),
+                  'fontVariantNumeric': cellElement.css('fontVariantNumeric'),
+                  'fontVariationSettings': cellElement.css('fontVariationSettings'),
+                  'fontWeight': cellElement.css('fontWeight')
+                };
 
               gridUtil.fakeElement(cell, style, function(newElm) {
-                
+      
                 var e = angular.element(newElm);
-                var width = gridUtil.elementWidth(newElm);
+                var width = gridUtil.elementWidth(e);
 
                 if (menuButton) {
                   var menuButtonWidth = gridUtil.elementWidth(menuButton);
@@ -558,7 +568,8 @@
 
           refreshCanvas(xDiff);
 
-          uiGridResizeColumnsService.fireColumnSizeChanged(uiGridCtrl.grid, col.colDef, xDiff);        };
+          uiGridResizeColumnsService.fireColumnSizeChanged(uiGridCtrl.grid, col.colDef, xDiff);        
+        };
         $elm.on('dblclick', dblClickFn);
 
         $elm.on('$destroy', function() {

--- a/src/features/resize-columns/js/ui-grid-column-resizer.js
+++ b/src/features/resize-columns/js/ui-grid-column-resizer.js
@@ -524,12 +524,21 @@
                 menuButton = angular.element(cell).parent()[0].querySelectorAll('.ui-grid-column-menu-button');
               }
 
+              //text becomes bold when font weight = 600
+              //this needs to be checked here because the fakeElement doesn't contain the font weight
+              var textIsBold = parseInt(angular.element(cell).css('font-weight')) > 500; 
+
               gridUtil.fakeElement(cell, {}, function(newElm) {
                 // Make the element float since it's a div and can expand to fill its container
                 var e = angular.element(newElm);
                 e.attr('style', 'float: left');
-
                 var width = gridUtil.elementWidth(e);
+                
+                if (textIsBold) {
+                  //1.05 is the smallest reasonable multiplier that prevents bold text from being truncated
+                  var boldTextOffsetMultiplier = 1.05;
+                  width = width * boldTextOffsetMultiplier;
+                }
 
                 if (menuButton) {
                   var menuButtonWidth = gridUtil.elementWidth(menuButton);

--- a/src/features/resize-columns/js/ui-grid-column-resizer.js
+++ b/src/features/resize-columns/js/ui-grid-column-resizer.js
@@ -522,30 +522,27 @@
                 menuButton = angular.element(cell).parent()[0].querySelectorAll('.ui-grid-column-menu-button');
               }
               // Make the element float since it's a div and can expand to fill its container
-              // include the cell's font properties since they affect the width.
-              var cellElement = angular.element(cell);            
-
-              var style = {
-                  'float':'left',
-                  'font': cellElement.css('font'),
-                  'fontDisplay': cellElement.css('fontDisplay'),
-                  'fontFamily': cellElement.css('fontFamily'),
-                  'fontFeatureSettings': cellElement.css('fontFeatureSettings'),
-                  'fontKerning': cellElement.css('fontKerning'),
-                  'fontSize': cellElement.css('fontSize'),
-                  'fontStretch': cellElement.css('fontStretch'),
-                  'fontStyle': cellElement.css('fontStyle'),
-                  'fontVariant': cellElement.css('fontVariant'),
-                  'fontVariantCaps': cellElement.css('fontVariantCaps'),
-                  'fontVariantEastAsian': cellElement.css('fontVariantEastAsian'),
-                  'fontVariantLigatures': cellElement.css('fontVariantLigatures'),
-                  'fontVariantNumeric': cellElement.css('fontVariantNumeric'),
-                  'fontVariationSettings': cellElement.css('fontVariationSettings'),
-                  'fontWeight': cellElement.css('fontWeight')
-                };
+              // include the cell's font properties since they affect the width. 
+              var style = angular.element(cell).css([
+                'font',
+                'fontDisplay',
+                'fontFamily',
+                'fontFeatureSettings',
+                'fontKerning',
+                'fontSize',
+                'fontStretch',
+                'fontStyle',
+                'fontVariant',
+                'fontVariantCaps',
+                'fontVariantEastAsian',
+                'fontVariantLigatures',
+                'fontVariantNumeric',
+                'fontVariationSettings',
+                'fontWeight']);
+              style.float = 'left';
 
               gridUtil.fakeElement(cell, style, function(newElm) {
-      
+                
                 var e = angular.element(newElm);
                 var width = gridUtil.elementWidth(e);
 
@@ -568,8 +565,7 @@
 
           refreshCanvas(xDiff);
 
-          uiGridResizeColumnsService.fireColumnSizeChanged(uiGridCtrl.grid, col.colDef, xDiff);        
-        };
+          uiGridResizeColumnsService.fireColumnSizeChanged(uiGridCtrl.grid, col.colDef, xDiff);        };
         $elm.on('dblclick', dblClickFn);
 
         $elm.on('$destroy', function() {


### PR DESCRIPTION
This works when the font-weight is what is driving the boldness. 

When you drive boldness with the font property, it is truncated. But since this apparently hasn't shown up anywhere else in our use of ng-grid, I think this is okay for now. 