### PR TITLE
Column drag start events could double register

### DIFF
--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -306,6 +306,7 @@
             post: function ($scope, $elm, $attrs, uiGridCtrl) {
               function enableColumnMove(){
                   if ($scope.grid.options.enableColumnMoving && $scope.col.colDef.enableColumnMoving) {
+                    offAllEvents();
                     onDownEvents();
                   }
                   else {

--- a/src/features/move-columns/js/column-movable.js
+++ b/src/features/move-columns/js/column-movable.js
@@ -305,13 +305,11 @@
           return {
             post: function ($scope, $elm, $attrs, uiGridCtrl) {
               function enableColumnMove(){
-                  if ($scope.grid.options.enableColumnMoving && $scope.col.colDef.enableColumnMoving) {
-                    offAllEvents();
-                    onDownEvents();
-                  }
-                  else {
-                    offAllEvents();
-                 }
+                offAllEvents();
+
+                if ($scope.grid.options.enableColumnMoving && $scope.col.colDef.enableColumnMoving) {
+                  onDownEvents();
+                }
               }
               $scope.$watch('grid.options.enableColumnMoving', enableColumnMove);
 


### PR DESCRIPTION
* Updated enableColumnMove() to unregister events before re-registering them, to ensure events won't be registered twice